### PR TITLE
Install required collections in container image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,7 +1,9 @@
-FROM registry.access.redhat.com/ubi8/python-39@sha256:496f9eee1837022e749a5f2d5c9ae91720200e03c38528894aee4eb6b3bb78b5
+FROM registry.access.redhat.com/ubi9/python-311:latest
 
 COPY requirements.txt ./
 RUN pip install -r requirements.txt
-COPY app.py ./
+RUN ansible-galaxy collection install dellemc.os9 && \
+	ansible-galaxy collection install amazon.aws
+COPY . ./
 
 CMD [ "gunicorn", "-b", "0.0.0.0:8000", "app:app"]


### PR DESCRIPTION
Install the dellemc.os9 and amazon.aws collections (both required by the ansible-switches repository).